### PR TITLE
Fix sdist publishing

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -31,7 +31,7 @@ jobs:
           poetry build -f sdist
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: python-sdist
           path: dist/*.tar.gz
@@ -102,7 +102,8 @@ jobs:
         uses: actions/download-artifact@v6
         with:
           path: dist/
-          pattern: sdist-*
+          pattern: python-sdist
+          merge-multiple: true
 
       - name: List artifacts
         run: ls -lah dist/


### PR DESCRIPTION
Current source distributions are not publishing.

The following fixes should re-enable them:
* Upgraded the artifact upload action for sdist from `actions/upload-artifact@v5` to `@v6` to match the uploads for wheels.
* Updated the sdist artifact download step to have matching artifact names.