### PR TITLE
Fix buffer overread in Voronoi norms property

### DIFF
--- a/src/cytriangle/cytriangleio.pyx
+++ b/src/cytriangle/cytriangleio.pyx
@@ -453,10 +453,9 @@ cdef class TriangleIO:
         if self._io.normlist is not NULL:
             norm_list = []
             for i in range(self._io.numberofedges):
-                norm_list.append({'ray_origin': [self._io.normlist[i * 4],
-                                                 self._io.normlist[i * 4 + 1]],
-                                  'ray_direction': [self._io.normlist[i * 4 + 2],
-                                                    self._io.normlist[i * 4 + 3]]})
+                norm_list.append({'ray_origin': [0.0, 0.0],
+                                  'ray_direction': [self._io.normlist[i * 2],
+                                                    self._io.normlist[i * 2 + 1]]})
             return norm_list
 
     def set_vertices(self, vertices):

--- a/tests/test_cytriangle.py
+++ b/tests/test_cytriangle.py
@@ -264,6 +264,36 @@ def test_refine_output_fields():
     ]
 
 
-def test_memory_deallocation():
+def test_voronoi_norms_match_edges():
+    """Verify norms contain correct direction vectors for Voronoi edges.
+
+    The C library allocates normlist as 2 REALs per edge. A previous bug
+    read 4 REALs per edge (i*4 indexing), which returned wrong values for
+    ray directions (reading adjacent edges' data) and read past allocated
+    memory for later edges.
+
+    For a unit square, the Voronoi diagram has 5 edges: 4 infinite rays
+    pointing in the cardinal directions and 1 finite edge with zero normal.
+    The exact direction values are deterministic.
+    """
+    test = CyTriangle(input_dict=simple_input)
+    test.voronoi()
+    norms = test.vorout.norms
+    expected_directions = [
+        [-1.0, 0.0],
+        [0.0, -1.0],
+        [0.0, 0.0],
+        [1.0, 0.0],
+        [0.0, 1.0],
+    ]
+    assert len(norms) == len(expected_directions)
+    for i, expected in enumerate(expected_directions):
+        assert norms[i]['ray_direction'] == expected, (
+            f"Edge {i}: expected direction {expected}, "
+            f"got {norms[i]['ray_direction']}"
+        )
+
+
+
     test = CyTriangle(input_dict=simple_input)
     del test  # Deallocate memory without errors


### PR DESCRIPTION
### Summary

The `norms` property in `cytriangleio.pyx` reads 4 REALs per edge (`i*4` indexing) from `normlist`, but the C Triangle library only allocates and writes 2 REALs per edge (`edges * 2 * sizeof(REAL)` at triangle.c line 14024). This means:

- **Edge 0** reads its own direction *plus* edge 1's direction (wrong values)
- **Edge 1** reads edge 2 and edge 3's data
- **Edge 2+** reads past the end of the allocated buffer (heap overread)

For a Voronoi diagram with `n` edges, the old code accesses index `4n - 1` from a buffer of size `2n`. Any diagram with 2+ edges triggers out-of-bounds reads.

### Test evidence

A test commit is included *before* the fix to demonstrate the failure. The test asserts exact expected direction vectors for a unit square's Voronoi diagram (4 infinite rays in cardinal directions + 1 finite edge):

```
FAILED tests/test_cytriangle.py::test_voronoi_norms_match_edges - AssertionError: Edge 0: expected direction [-1.0, 0.0], got [0.0, -1.0]

    assert norms[i]['ray_direction'] == expected, (
        f"Edge {i}: expected direction {expected}, "
        f"got {norms[i]['ray_direction']}"
    )
E   AssertionError: Edge 0: expected direction [-1.0, 0.0], got [0.0, -1.0]
E   assert [0.0, -1.0] == [-1.0, 0.0]
```

Edge 0's `ray_direction` returned `[0.0, -1.0]` (edge 1's data at indices 2,3) instead of `[-1.0, 0.0]` (the actual values at indices 0,1).

### Fix

Change indexing from `i * 4` to `i * 2` to match the C library's allocation and write pattern. The `ray_origin` field is set to `[0.0, 0.0]` — the C library does not store origin data in `normlist` (Voronoi vertex positions are in the output `pointlist`).

### What the C library actually writes

For each Voronoi edge, `normlist` stores exactly 2 values:
- **Infinite rays**: the direction vector `(dy, -dx)` of the dual Delaunay edge
- **Finite edges**: `(0.0, 0.0)`

```
normlist memory layout (5 edges, 10 doubles):
  edge 0: [-1.0, 0.0]   indices 0,1
  edge 1: [ 0.0,-1.0]   indices 2,3
  edge 2: [ 0.0, 0.0]   indices 4,5  (finite)
  edge 3: [ 1.0, 0.0]   indices 6,7
  edge 4: [ 0.0, 1.0]   indices 8,9
```

The old `i*4` code read indices 0-3 for edge 0, 4-7 for edge 1, and 8-11+ for edge 2 (out of bounds).
