### PR TITLE
Fix flag validation regexes for q and a flags

### DIFF
--- a/src/cytriangle/cytriangle.pyx
+++ b/src/cytriangle/cytriangle.pyx
@@ -81,12 +81,12 @@ cdef class CyTriangle:
                 raise ValueError("Segment list must be provided when using 'p' flag")
         if "a" in opts:
             if not ('triangle_max_area' in self._in.to_dict() or 'A'
-                    in opts or bool(re.search(r'a[\d.*.]+\d.*', opts))):
+                    in opts or bool(re.search(r'a\d+(\.\d+)?', opts))):
                 raise ValueError("""When using 'a' flag for area constraints, a global
                                  area flag (e.g. a0.2), 'A' flag, or local triangle area
                                  constraint list (e.g. [3.0, 1.0]) must be provided""")
         if "q" in opts:
-            if not bool(re.search(r'q[\d.*.]+\d.*', opts)):
+            if not bool(re.search(r'q\d+(\.\d+)?', opts)):
                 raise ValueError("""When using 'q' flag for minimum angles, an angle
                                  must be provided""")
 


### PR DESCRIPTION
### Summary

The `validate_input_flags` method in `cytriangle.pyx` uses a regex to check that the `q` and `a` flags have a numeric argument. The existing regex `r'q[\d.*.]+\d.*'` requires at least two characters after `q`, so valid single-digit inputs like `q5` (5-degree minimum angle) are incorrectly rejected even though Triangle accepts them.

The `.*` inside the character class `[\d.*.]+` is also misleading — it matches literal `.` and `*` characters, not "any character" as likely intended.

### What changed

Both the `q` and `a` flag regexes are replaced with `r'q\d+(\.\d+)?'` and `r'a\d+(\.\d+)?'` respectively. This correctly matches:

- `q5` — single-digit angle
- `q30` — multi-digit angle
- `q33.9` — decimal angle
- `a0.2` — area constraint
- `a100` — integer area constraint

### Before

```python
# Rejects q5 (requires 2+ chars after q)
re.search(r'q[\d.*.]+\d.*', opts)
re.search(r'a[\d.*.]+\d.*', opts)
```

### After

```python
# Accepts q5, q30, q33.9
re.search(r'q\d+(\.\d+)?', opts)
re.search(r'a\d+(\.\d+)?', opts)
```

### Note

Triangle itself defaults to 20 degrees when given a bare `q` with no number. This fix still requires a numeric argument — matching the existing validation intent rather than Triangle's full behavior.
